### PR TITLE
add instructions for ignoredDevices

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Configuration sample:
     {
         "platform": "LifxLan",
         "name": "LiFx",
-		"ignoredDevices" : ["abcd1234561", "efabcd6721"]
+        "ignoredDevices" : ["abcd1234561", "efabcd6721"]
     }
 ]
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ Configuration sample:
 "platforms": [
     {
         "platform": "LifxLan",
-        "name": "LiFx"
+        "name": "LiFx",
+		"ignoredDevices" : ["abcd1234561", "efabcd6721"]
     }
 ]
 

--- a/index.js
+++ b/index.js
@@ -8,7 +8,9 @@
 //         "platform": "LifxLan",           // required
 //         "name": "LiFx LAN",              // required
 //         "duration": 1000,                // optional, the time to fade on/off in milliseconds
-
+//         "ignoredDevices": ["abcd1234561", "efabcd6721"]
+//                                          // optional: Array of bulb ids to ignore (from accessory.context.id)
+//                                          // If you have a switch in your HomeWizard you don't want to expose to Siri. Put the ids in here and they will be ignored.
 //         ** optional node-lifx parameters **
 //         "broadcast": '255.255.255.255',   // optional: Broadcast address for bulb discovery
 //         "lightOfflineTolerance": 3,       // optional: A light is offline if not seen for the given amount of discoveries


### PR DESCRIPTION
I have a couple of Gen2 and Gen3 (Homekit compatible) bulbs, so I was looking for a way to have homebridge ignore the Gen3 devices. Looking at the code, I found this is already supported, so adding this to the README for anyone who is looking for something similar.