### PR TITLE
Create a whitelist of bulbs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 [![npm package](https://nodei.co/npm/homebridge-lifx-lan.png?downloads=true&downloadRank=true&stars=true)](https://nodei.co/npm/homebridge-lifx-lan/)
 
-[![NPM Version](https://img.shields.io/npm/v/homebridge-lifx-lan.svg)](https://www.npmjs.com/package/homebridge-lifx-lan)
-[![Dependency Status](https://img.shields.io/versioneye/d/nodejs/homebridge-lifx-lan.svg)](https://www.versioneye.com/nodejs/homebridge-lifx-lan/)
+[![donate](https://img.shields.io/badge/%24-Buy%20me%20a%20coffee-ff69b4.svg)](https://www.buymeacoffee.com/devbobo)
 [![Slack Channel](https://img.shields.io/badge/slack-homebridge--lifx-e01563.svg)](https://homebridgeteam.slack.com/messages/C1NE2GM0S/)
 
 LiFx LAN platform plugin for [Homebridge](https://github.com/nfarina/homebridge).


### PR DESCRIPTION
Now that the newer LIFX bulbs are HomeKit enabled, it may be more convenient to list the bulbs you want to control via Homebridge instead of creating a list of all the ones you don't. This provides both  whitelist (`enabledDevices`) and blacklist (`ignoredDevices`) functionality.