### PR TITLE
Support addressing lights by IP address

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,6 +18,8 @@
 //         "resendPacketDelay": 150,         // optional: delay between packages if light did not receive a packet (for setting methods with callback)
 //         "resendMaxTimes": 3,              // optional: resend packages x times if light did not receive a packet (for setting methods with callback)
 //         "debug": false,                   // optional: logs all messages in console if turned on
+//         "lights": ["192.168.2.14","192.168.2.15"] 
+//                                           // optional: Array of bulb IP addresses. This is useful if the lights are on a different network than homebridge
 //         "address": '0.0.0.0'              // optional: specify which ipv4 address to bind to
 //     }
 // ],
@@ -173,7 +175,8 @@ function LifxLanPlatform(log, config, api) {
             messageHandlerTimeout:  this.config.messageHandlerTimeout || 2500,
             resendMaxTimes:         this.config.resendMaxTimes || 3,
             resendPacketDelay:      this.config.resendPacketDelay || 500,
-            address:                this.config.address || '0.0.0.0'
+            address:                this.config.address || '0.0.0.0',
+            lights:                 this.config.lights || []
         });
     }.bind(this));
 }


### PR DESCRIPTION
Previous to this commit there was no way to control bulbs that were on a
different network that homebridge. The only discovery method was through
network broadcasts, which won't work across VLANs.

The node-lifx library supports addressing bulbs by their IP, but this
homebridge plugin did not. This commit adds support by adding the
"lights" configuration option that accepts an array of IP addresses.